### PR TITLE
Fix region setting

### DIFF
--- a/ViewFinder.qml
+++ b/ViewFinder.qml
@@ -17,8 +17,8 @@ Window {
     
     signal selected(rect frame)
     
-    onActiveChanged: {
-        if (active) 
+    onVisibleChanged: {
+        if (visible)
             region = Qt.rect(0, 0, Screen.width, Screen.height)
     }
     


### PR DESCRIPTION
On my machine active state of viewfinder is always true for some reason, and onActiveChanged is still called when viewfinder is closed. So, full-screen region is always selected.
Visibility check instead of activeness seem to be working just fine